### PR TITLE
Fix GitHub Pages build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ npm run dev
 npm run deploy
 ```
 
-The `base` option in `vite.config.js` is set to `/gamification/` so the app works when deployed on GitHub Pages.
+The `base` option in `vite.config.js` is set to `./` so the app works when deployed on GitHub Pages or any subdirectory.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,11 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.jest,
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/index.html
+++ b/index.html
@@ -11,6 +11,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/gamification/',
+  base: './',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- make Vite output use relative URLs
- point index.html to a relative main.jsx path
- allow Node/Jest globals in ESLint
- update README note about Vite `base`
- add `.gitignore`

## Testing
- `npm run build`
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866b1dd67ec83269ba3818edf2b561d